### PR TITLE
[Feat] api 응답 통일

### DIFF
--- a/src/main/java/com/muluck/global/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/muluck/global/exception/ApiExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.muluck.global.exception;
+
+import com.muluck.global.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(BaseException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
+        log.error("BaseException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode));
+    }
+
+    // @Valid 검증 실패 (RequestBody)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException: {}", e.getMessage());
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    // @ModelAttribute 검증 실패
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
+        log.error("BindException: {}", e.getMessage());
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    // 잘못된 타입 요청
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.fail(ErrorCode.INVALID_TYPE_VALUE));
+    }
+
+    // 지원하지 않는 HTTP 메서드
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return ResponseEntity
+                .status(405)
+                .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    // 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage(), e);
+        return ResponseEntity
+                .internalServerError()
+                .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/muluck/global/exception/BaseException.java
+++ b/src/main/java/com/muluck/global/exception/BaseException.java
@@ -1,0 +1,19 @@
+package com.muluck.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/muluck/global/exception/ErrorCode.java
+++ b/src/main/java/com/muluck/global/exception/ErrorCode.java
@@ -1,0 +1,38 @@
+package com.muluck.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C002", "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "허용되지 않은 메서드입니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "잘못된 타입입니다."),
+
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+
+    // PlantFolder
+    PLANT_FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "식물 폴더를 찾을 수 없습니다."),
+
+    // Diagnosis
+    DIAGNOSIS_NOT_FOUND(HttpStatus.NOT_FOUND, "D001", "진단 기록을 찾을 수 없습니다."),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "D002", "지원하지 않는 이미지 형식입니다."),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "D003", "이미지 업로드에 실패했습니다."),
+
+    // Result
+    RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "진단 결과를 찾을 수 없습니다."),
+
+    // Azure
+    AZURE_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "A001", "Azure 서비스 연결에 실패했습니다."),
+    AZURE_AI_ANALYSIS_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "A002", "AI 분석에 실패했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/muluck/global/response/ApiResponse.java
+++ b/src/main/java/com/muluck/global/response/ApiResponse.java
@@ -1,0 +1,75 @@
+package com.muluck.global.response;
+
+import com.muluck.global.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse<T> {
+
+    private Boolean isSuccess;
+    private String code;
+    private String message;
+    private T data;
+
+    // 성공 응답 - 데이터 있음
+    public static <T> ApiResponse<T> success(T data) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = true;
+        response.code = "SUCCESS";
+        response.message = "요청이 성공했습니다.";
+        response.data = data;
+        return response;
+    }
+
+    // 성공 응답 - 커스텀 메시지
+    public static <T> ApiResponse<T> success(String message, T data) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = true;
+        response.code = "SUCCESS";
+        response.message = message;
+        response.data = data;
+        return response;
+    }
+
+    // 성공 응답 - 데이터 없음 (삭제, 수정 등)
+    public static <T> ApiResponse<T> successWithNoContent() {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = true;
+        response.code = "SUCCESS";
+        response.message = "요청이 성공했습니다.";
+        response.data = null;
+        return response;
+    }
+
+    public static <T> ApiResponse<T> successWithNoContent(String message) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = true;
+        response.code = "SUCCESS";
+        response.message = message;
+        response.data = null;
+        return response;
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = false;
+        response.code = errorCode.getCode();
+        response.message = errorCode.getMessage();
+        response.data = null;
+        return response;
+    }
+
+    // 실패 응답 - 커스텀 메시지
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode, String message) {
+        ApiResponse<T> response = new ApiResponse<>();
+        response.isSuccess = false;
+        response.code = errorCode.getCode();
+        response.message = message;
+        response.data = null;
+        return response;
+    }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #3 


## ✏️ 작업 내용

- API 응답 통일을 위한 글로벌 예외 처리 구조 구축
  - ErrorCode: 도메인별 에러 코드 정의 (Common, User, PlantFolder, Diagnosis, Result, Azure)
  - BaseException: 커스텀 예외 클래스
  - ApiResponse: 통일된 응답 형식 (isSuccess, code, message, data)
  - ApiExceptionHandler: 전역 예외 처리 및 Validation 에러 핸들링


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
