### PR TITLE
[Fix] riskLevel column 추가

### DIFF
--- a/src/main/java/com/muluck/Main.java
+++ b/src/main/java/com/muluck/Main.java
@@ -2,10 +2,8 @@ package com.muluck;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class Main {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);

--- a/src/main/java/com/muluck/domain/DiseaseResult.java
+++ b/src/main/java/com/muluck/domain/DiseaseResult.java
@@ -35,6 +35,9 @@ public class DiseaseResult extends BaseEntity {
     @Column(name = "cause", columnDefinition = "TEXT")
     private String cause;
 
+    @Column(name = "risk_level", length = 20)
+    private String riskLevel;
+
     @Column(name = "management_guide", columnDefinition = "TEXT")
     private String managementGuide;
 


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #15 


## ✏️ 작업 내용

### 빌드 에러 해결
- `DiseaseResult` 엔티티에 `riskLevel` 필드 재추가
- `@EnableJpaAuditing` 중복 선언 제거

1. **riskLevel 필드 추가**
   - 다른 팀원의 코드(`DiseaseResultDto.java`)에서 `getRiskLevel()` 사용
   - 빌드 실패 방지를 위해 `DiseaseResult` 엔티티에 필드 재추가
   - 실제 구현은 다른 팀원이 담당 예정

2. **JPA Auditing 중복 제거**
   - `Main.java`와 `JpaAuditingConfig.java`에 `@EnableJpaAuditing` 중복 선언
   - `Main.java`에서 제거, Config 클래스에만 유지


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
