### PR TITLE
feat: candidates_3 케이스 각 후보별 description 추가

### DIFF
--- a/src/main/java/com/muluck/service/OpenAIClient.java
+++ b/src/main/java/com/muluck/service/OpenAIClient.java
@@ -52,6 +52,26 @@ public class OpenAIClient {
         }
     }
 
+    // GPT-4o-mini를 호출하여 3개 후보 질병을 분석
+    public List<GptPromptRequestDto.DiseaseCandidate> analyzeCandidates(GptPromptRequestDto promptRequest) {
+        try {
+            String systemPrompt = buildSystemPrompt();
+            String userPrompt = buildUserPrompt(promptRequest);
+
+            String gptResponse = callGptApi(systemPrompt, userPrompt);
+            
+            // 전체 JSON을 GptPromptRequestDto로 파싱
+            GptPromptRequestDto parsedResponse = objectMapper.readValue(gptResponse, GptPromptRequestDto.class);
+            
+            // candidates 추출 (description이 채워진 상태)
+            return parsedResponse.getCandidates();
+
+        } catch (Exception e) {
+            log.error("Failed to analyze candidates with GPT", e);
+            throw new RuntimeException("후보 질병 분석에 실패했습니다.", e);
+        }
+    }
+
     // GPT-4o-mini를 호출하여 건강한 식물 관리 팁 생성
     public List<String> generateHealthyCareTips(String crop) {
         try {


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #20 


## ✏️ 작업 내용

- CANDIDATES_3 케이스에서 candidates 리스트에 description 추가
- OpenAIClient에 `analyzeCandidates()` 메서드 추가하여 3개 후보를 한 번에 gpt-4o-mini로 분석
- DiagnosisService의 `handleCandidates3()` 메서드 수정하여 각 후보에 gpt-4o-mini 생성 description 포함

## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
